### PR TITLE
BAC-2972 : Color hipchap messages based on regexp

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -1,0 +1,7 @@
+{
+  "Colors": {
+    "\\[INFO\\]": "gray",
+    "\\[WARNING\\]": "yellow",
+    "\\[BLOCKER\\]": "red"
+  }
+}


### PR DESCRIPTION
# Features

Can now render hipchat message in different colors.
At startup, the server load a `config.json`file lik in the example below

``` json
{
  "Colors": {
    "\\[INFO\\]": "gray",
    "\\[WARNING\\]": "yellow",
    "\\[BLOCKER\\]": "red"
  }
}
```

`Colors`is a map from a regexp to an hipchat color. The sever will apply the first matched regexp to the subject of the message
# Notes

Currently we recompile all regexp for each request. we should do that only at startup
# Jira

https://ifeelgoods.atlassian.net/browse/BAC-2972
